### PR TITLE
Update cl-reddit.lisp

### DIFF
--- a/cl-reddit.lisp
+++ b/cl-reddit.lisp
@@ -113,7 +113,7 @@
   "Gets messages from inbox for user user.
    where can be one of 'inbox 'unread 'sent
    "
-  (let ((url (format nil "~a/message/~a.json" *reddit* (string-symbol where))))
+  (let ((url (format nil "~a/message/~a.json" *reddit* (symbol-string where))))
     (with-user (user)
       (parse-json (get-json url user)))))
 


### PR DESCRIPTION
In get-message function on line 122, (string-symbol where) results in a error message saying the function string-symbol is undefined. The actual function call here should be (symbol-string where).
