### PR TITLE
Added macro param-push, simplifying a lot of code

### DIFF
--- a/cl-reddit.lisp
+++ b/cl-reddit.lisp
@@ -157,20 +157,6 @@
       (listing-children 
         (parse-json (get-json url user))))))
 
-(defmacro param-push (&rest commands)
-  (flet ((process-commands (commands)
-           (let (stack)
-             (loop for c in commands do
-                  (typecase c
-                    (symbol (push `(,c ,(string-downcase c)) stack))
-                    (string (setf (car stack) `(,(caar stack) ,c)))))
-             stack)))
-    `(progn
-       ,@(loop for c in (process-commands commands)
-            collect
-              `(when ,(car c)
-                 (push `(,',(cadr c) . ,,(car c)) params))))))
-
 (defun get-reddits-mine (user &key (where 'subscriber) after before count limit show target)
   "Gets listing of subreddits for user.
    where can be one of 'subscriber 'moderator 'contributorfor."


### PR DESCRIPTION
I've added a new macro, param-push, that simplifies some of the code in cl-reddit.lisp

The macro could be extended to work for some more extensive syntax, though I've yet to do this. 

It is currently undocumented but here's an example:

(macroexpand-1 '(param-push
     after before count limit show target))

=>

(PROGN
 (WHEN TARGET (PUSH `("target" . TARGET) PARAMS))
 (WHEN SHOW (PUSH`("show" . SHOW) PARAMS))
 (WHEN LIMIT (PUSH `("limit" . LIMIT) PARAMS))
 (WHEN COUNT (PUSH`("count" . COUNT) PARAMS))
 (WHEN BEFORE (PUSH `("before" . BEFORE) PARAMS))
 (WHEN AFTER (PUSH`("after" . AFTER) PARAMS)))
